### PR TITLE
Update abx-micro-prescription.sql

### DIFF
--- a/query/tbls/abx-micro-prescription.sql
+++ b/query/tbls/abx-micro-prescription.sql
@@ -101,7 +101,7 @@ select
 
   -- time of suspected infection: either the culture time (if before antibiotic), or the antibiotic time
   , case
-      when coalesce(last72_charttime,next24_charttime) is null
+      when coalesce(last72_charttime,antibiotic_time) is null
         then 0
       else 1 end as suspected_infection
 

--- a/query/tbls/abx-micro-prescription.sql
+++ b/query/tbls/abx-micro-prescription.sql
@@ -105,7 +105,7 @@ select
         then 0
       else 1 end as suspected_infection
 
-  , coalesce(last72_charttime,next24_charttime) as suspected_infection_time
+  , coalesce(last72_charttime,antibiotic_time) as suspected_infection_time
 
   -- the specimen that was cultured
   , case


### PR DESCRIPTION
Updated Line 108 to  be in line to be inline to Seymour's Suspicion of Infection Time.

"We required the combination of culture and antibiotic start time to occur within a specific time epoch. If the antibiotic was given first, the culture sampling must have been obtained within 24 hours. If the culture sampling was first, the antibiotic must have been ordered within 72 hours. The “onset” of infection was defined as the time at which the first of these 2 events occurred"

Full Text of Seymour et al reference: https://jamanetwork.com/journals/jama/fullarticle/2492875